### PR TITLE
ShouldExistInOrderTest.kt

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
@@ -26,7 +26,7 @@ fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> 
 
    MatcherResult(
       subsequenceIndex == predicates.size,
-      { "${actual.print().value} did not match the predicates ${predicates.print().value} in order" },
+      { "${actual.print().value} did not match the predicates ${predicates.print().value} in order. Predicate number $subsequenceIndex did not match." },
       { "${actual.print().value} should not match the predicates ${predicates.print().value} in order" }
    )
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldExistInOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldExistInOrderTest.kt
@@ -1,0 +1,27 @@
+package com.sksamuel.kotest.matchers.collections
+
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldExistInOrder
+import io.kotest.matchers.shouldBe
+
+class ShouldExistInOrderTest: WordSpec() {
+   init {
+       "shouldExistInOrder" should {
+          "pass" {
+              listOf(1, 2).shouldExistInOrder(
+                 { i: Int -> i < 2 },
+             { i: Int -> i < 3 }
+              )
+          }
+          "fail with clear message" {
+             shouldThrowAny {
+                listOf(1, 2).shouldExistInOrder(
+                   { i: Int -> i < 2 },
+                   { i: Int -> i < 2 }
+                )
+             }.message shouldBe "[1, 2] did not match the predicates [(kotlin.Int) -> kotlin.Boolean, (kotlin.Int) -> kotlin.Boolean] in order. Predicate number 1 did not match."
+          }
+       }
+   }
+}


### PR DESCRIPTION
Provide more details when `shouldExistInOrder` fails, give the number of failing predicate, for example add the following
"Predicate number 1 did not match"

```
         "fail with clear message" {
             shouldThrowAny {
                listOf(1, 2).shouldExistInOrder(
                   { i: Int -> i < 2 },
                   { i: Int -> i < 2 }
                )
             }.message shouldBe "[1, 2] did not match the predicates [(kotlin.Int) -> kotlin.Boolean, (kotlin.Int) -> kotlin.Boolean] in order. Predicate number 1 did not match."
          }
```